### PR TITLE
Bob order date UI fix

### DIFF
--- a/orca-ui/src/app/orders/OrdersOverview.tsx
+++ b/orca-ui/src/app/orders/OrdersOverview.tsx
@@ -7,13 +7,6 @@ import { Textarea } from "@/components/ui/textarea";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { supabase } from "@/lib/supabaseClient";
 
-interface Product {
-  product_name: string;
-  quantity: number;
-  unit: string;
-  delivery_date?: string;
-}
-
 interface OrderLine {
   order_id: string;
   product_name: string;
@@ -28,7 +21,7 @@ interface Order {
   subject: string;
   sender: string;
   email_body: string;
-  parsed_data: any;
+  parsed_data: Record<string, unknown>;
 }
 
 export default function OrdersOverview({ orders: initialOrders }: { orders: Order[] }) {

--- a/orca-ui/src/app/orders/page.tsx
+++ b/orca-ui/src/app/orders/page.tsx
@@ -12,14 +12,7 @@ interface Order {
     subject: string;
     sender: string;
     email_body: string;
-    parsed_data: {
-      products?: {
-        name: string;
-        quantity: number;
-        unit: string;
-      }[];
-      [key: string]: unknown;
-    };
+    parsed_data: any;
   }
   
 

--- a/orca-ui/src/app/orders/page.tsx
+++ b/orca-ui/src/app/orders/page.tsx
@@ -12,7 +12,7 @@ interface Order {
     subject: string;
     sender: string;
     email_body: string;
-    parsed_data: any;
+    parsed_data: Record<string, unknown>;
   }
   
 

--- a/orca/import_structured_orders.py
+++ b/orca/import_structured_orders.py
@@ -52,7 +52,8 @@ def import_structured_orders():
                     "order_id": structured_id,
                     "product_name": product.get("name"),
                     "quantity": product.get("quantity"),
-                    "unit": product.get("unit")
+                    "unit": product.get("unit"),
+                    "delivery_date": product.get("delivery_date") or parsed.get("delivery_date")
                 }
                 supabase.table("order_lines").insert(line_data).execute()
 


### PR DESCRIPTION
updated the order_lines table with a delivery date field
we now read from this table in the front end in stead of directly from the json we got from llm
this allows us to directly update order_lines in the backend before we send out the order to trello
also gives better order correction ui opportunities so anyone can change orders when incorrect created from email by llm, in stead of updating it by json structure as is now