### PR TITLE
Rebuild order date UI & fix email fetch error

### DIFF
--- a/orca-ui/src/app/orders/OrdersOverview.tsx
+++ b/orca-ui/src/app/orders/OrdersOverview.tsx
@@ -80,16 +80,18 @@ export default function OrdersOverview({ orders: initialOrders }: { orders: Orde
   const handleProcessAll = async () => {
     setProcessing(true);
     setProcessResult(null);
+  
     try {
       const res = await fetch("https://projectorca.onrender.com/process-all", { method: "POST" });
   
-      let json = null;
+      let json: any = null;
       try {
         json = await res.json();
-      } catch (e) {
+      } catch {
         const text = await res.text();
-        console.warn("⚠️ Kon geen JSON parsen. Response:", text);
-        throw new Error("Backend gaf geen geldige JSON terug");
+        console.warn("⚠️ Backend gaf geen JSON, maar wel tekst:", text);
+        setProcessResult(`⚠️ Backend gaf geen JSON terug. Response: ${text}`);
+        return; // Stop hier
       }
   
       if (!res.ok || json?.status === "error") {
@@ -100,9 +102,10 @@ export default function OrdersOverview({ orders: initialOrders }: { orders: Orde
         window.location.reload();
       }
   
-    } catch (e: any) {
+    } catch (e: unknown) {
       console.error("❌ Verwerken mislukt:", e);
-      setProcessResult("❌ Fout bij verbinden met backend: " + e.message);
+      const message = e instanceof Error ? e.message : "Onbekende fout";
+      setProcessResult("❌ Fout bij verbinden met backend: " + message);
     } finally {
       setProcessing(false);
     }

--- a/orca-ui/src/app/orders/OrdersOverview.tsx
+++ b/orca-ui/src/app/orders/OrdersOverview.tsx
@@ -77,28 +77,41 @@ export default function OrdersOverview({ orders: initialOrders }: { orders: Orde
     }
   };
 
+  type ProcessAllResponse = {
+    status: "success" | "error";
+    message?: string;
+    email?: { emails_found: number };
+    llm?: { parsed: number };
+    import?: { orders_imported: number };
+  };
+  
   const handleProcessAll = async () => {
     setProcessing(true);
     setProcessResult(null);
   
     try {
-      const res = await fetch("https://projectorca.onrender.com/process-all", { method: "POST" });
+      const res = await fetch("https://projectorca.onrender.com/process-all", {
+        method: "POST",
+      });
   
-      let json: any = null;
+      let json: ProcessAllResponse | null = null;
+  
       try {
-        json = await res.json();
+        json = (await res.json()) as ProcessAllResponse;
       } catch {
         const text = await res.text();
         console.warn("⚠️ Backend gaf geen JSON, maar wel tekst:", text);
         setProcessResult(`⚠️ Backend gaf geen JSON terug. Response: ${text}`);
-        return; // Stop hier
+        return;
       }
   
-      if (!res.ok || json?.status === "error") {
-        const msg = json?.message || `Onbekende fout (${res.status})`;
+      if (!res.ok || json.status === "error") {
+        const msg = json.message || `Onbekende fout (${res.status})`;
         setProcessResult(`❌ Fout: ${msg}`);
       } else {
-        setProcessResult(`📥 ${json.email?.emails_found ?? "?"} mails · 🧠 ${json.llm?.parsed ?? "?"} parsed · ✅ ${json.import?.orders_imported ?? "?"} orders`);
+        setProcessResult(
+          `📥 ${json.email?.emails_found ?? "?"} mails · 🧠 ${json.llm?.parsed ?? "?"} parsed · ✅ ${json.import?.orders_imported ?? "?"} orders`
+        );
         window.location.reload();
       }
   

--- a/orca/import_structured_orders.py
+++ b/orca/import_structured_orders.py
@@ -36,7 +36,6 @@ def import_structured_orders():
                 "order_number": parsed.get("order_number"),
                 "customer_name": parsed.get("customer_name"),
                 "order_date": parsed.get("order_date"),
-                "delivery_date": parsed.get("delivery_date"),
                 "special_notes": parsed.get("special_notes"),
             }
 
@@ -52,8 +51,8 @@ def import_structured_orders():
                     "order_id": structured_id,
                     "product_name": product.get("name"),
                     "quantity": product.get("quantity"),
+                    "delivery_date": product.get("delivery_date"),
                     "unit": product.get("unit"),
-                    "delivery_date": product.get("delivery_date") or parsed.get("delivery_date")
                 }
                 supabase.table("order_lines").insert(line_data).execute()
 

--- a/orca/llm_parser.py
+++ b/orca/llm_parser.py
@@ -39,13 +39,13 @@ Antwoord in exact dit JSON-format:
   "order_number": null,
   "customer_name": "...",
   "order_date": "YYYY-MM-DD",
-  "delivery_date": "YYYY-MM-DD",
   "special_notes": "...",
   "products": [
     {{
       "name": "...",
       "quantity": ...,
-      "unit": "..."
+      "unit": "...",
+      "delivery_date": "YYYY-MM-DD",
     }}
   ]
 }}

--- a/orca/llm_parser.py
+++ b/orca/llm_parser.py
@@ -24,7 +24,7 @@ def extract_order_from_email(email_body):
 Je bent een slimme order-assistent. Haal de volgende informatie uit de onderstaande e-mail en geef het resultaat als JSON.
 
 - Geef datums altijd in formaat "YYYY-MM-DD" (ISO 8601).
-- quantity is komt eigenlijk altijd in stuks, tenzij anders vermeld, dus 10 broden is product brood en quantity 10 stuks
+- measuring unitis komt eigenlijk altijd in stuks, tenzij anders vermeld, dus 10 broden is product brood en quantity 10 stuks
 - Vertaal relatieve termen zoals "morgen", "dinsdag" of "volgende week" naar een echte datum, gerekend vanaf vandaag: {today}.
 - Als een datum niet genoemd wordt, gebruik null.
 - Gebruik geen Markdown, geen codeblokken – alleen de JSON zelf.

--- a/orca/llm_parser.py
+++ b/orca/llm_parser.py
@@ -24,6 +24,7 @@ def extract_order_from_email(email_body):
 Je bent een slimme order-assistent. Haal de volgende informatie uit de onderstaande e-mail en geef het resultaat als JSON.
 
 - Geef datums altijd in formaat "YYYY-MM-DD" (ISO 8601).
+- quantity is komt eigenlijk altijd in stuks, tenzij anders vermeld, dus 10 broden is product brood en quantity 10 stuks
 - Vertaal relatieve termen zoals "morgen", "dinsdag" of "volgende week" naar een echte datum, gerekend vanaf vandaag: {today}.
 - Als een datum niet genoemd wordt, gebruik null.
 - Gebruik geen Markdown, geen codeblokken – alleen de JSON zelf.


### PR DESCRIPTION
Changes
✅ Updated JSON structure in LLM_parser
Delivery dates are now consistently assigned at the product-day level within the JSON structure.

This ensures that delivery dates are displayed correctly on the frontend, even though the backend does not yet read from this new structure.

For now (e.g. for tomorrow's orders), this is sufficient, as delivery dates are still stored correctly at the orderLine level.

🐛 Fixed email fetch error
Resolved a bug that caused an error when retrieving emails from the backend.

📝 Prompt update
Added clarification: All product quantities are measured in units (stuks) unless stated otherwise.


how to test?
Send new order, 2 types:
- with an order for one specific day
- with orders for multiple days

get new orders in via button top right in app

check if all dates are filled
chech you can send the order to trello
