### PR TITLE
Refactor order handling to use emails instead of orders

### DIFF
--- a/orca-ui/src/app/orders/OrdersOverview.tsx
+++ b/orca-ui/src/app/orders/OrdersOverview.tsx
@@ -98,9 +98,9 @@ export default function OrdersOverview({ orders: initialOrders }: { orders: Orde
 const newOrders: { id: string }[] = json.import?.new_orders ?? [];
 
 if (newOrders.length > 0) {
-  // Get all orders
+  // Get all emails
   const { data: ordersData, error: ordersError } = await supabase
-    .from("orders")
+    .from("emails")
     .select("*")
     .order("created_at", { ascending: false });
 
@@ -112,9 +112,9 @@ if (newOrders.length > 0) {
     .from("order_lines")
     .select("id, order_id, product_name, quantity, unit, is_exported");
 
-  // Get the mapping of email_id to structured_order_id
+  // Get the mapping of email_id to order_id
   const { data: structuredOrders } = await supabase
-    .from("orders_structured")
+    .from("orders")
     .select("id, email_id");
 
   // Create a map of all order lines for enriching JSON with IDs

--- a/orca-ui/src/app/orders/page.tsx
+++ b/orca-ui/src/app/orders/page.tsx
@@ -34,9 +34,9 @@ export default function Page() {
   useEffect(() => {
     const fetchOrders = async () => {
       try {
-        // First get all orders
+        // First get all emails
         const { data: ordersData, error: ordersError } = await supabase
-          .from("orders")
+          .from("emails")
           .select("*")
           .order("created_at", { ascending: false });
 
@@ -54,9 +54,9 @@ export default function Page() {
           .from("order_lines")
           .select("id, order_id, product_name, quantity, unit, is_exported");
 
-        // Get the mapping of email_id to structured_order_id
+        // Get the mapping of email_id to order_id
         const { data: structuredOrders } = await supabase
-          .from("orders_structured")
+          .from("orders")
           .select("id, email_id");
 
         // Create a map of structured order IDs to their exported products

--- a/orca/import_structured_orders.py
+++ b/orca/import_structured_orders.py
@@ -12,28 +12,28 @@ supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
 
 def import_structured_orders():
     # ⬇️ Selecteer orders met LLM output die nog niet zijn geïmporteerd
-    response = supabase.table("orders") \
+    response = supabase.table("emails") \
         .select("*") \
         .eq("llm_processed", True) \
         .eq("structured_imported", False) \
         .execute()
 
-    orders = response.data
-    print(f"📥 Orders klaar voor import: {len(orders)}")
+    emails = response.data
+    print(f"📥 Emails klaar voor import: {len(emails)}")
 
     imported = 0
     new_orders = []
 
-    for order in orders:
+    for email in emails:
         try:
-            email_id = order["id"]
-            parsed = order["parsed_data"]
+            email_id = email["id"]
+            parsed = email["parsed_data"]
 
             if not parsed:
-                print(f"⚠️ Geen parsed_data bij e-mail: {order['subject']}")
+                print(f"⚠️ Geen parsed_data bij e-mail: {email['subject']}")
                 continue
 
-            # ⬇️ Insert in orders_structured
+            # ⬇️ Insert in orders
             order_structured_data = {
                 "email_id": email_id,
                 "order_number": parsed.get("order_number"),
@@ -42,10 +42,10 @@ def import_structured_orders():
                 "special_notes": parsed.get("special_notes"),
             }
 
-            response_structured = supabase.table("orders_structured").insert(order_structured_data).execute()
+            response_structured = supabase.table("orders").insert(order_structured_data).execute()
             structured_id = response_structured.data[0]["id"]
 
-            print(f"✅ Order ingevoerd: {order['subject']} → order_id = {structured_id}")
+            print(f"✅ Order ingevoerd: {email['subject']} → order_id = {structured_id}")
 
             # ⬇️ Insert alle producten in order_lines
             products = parsed.get("products", [])
@@ -60,19 +60,19 @@ def import_structured_orders():
                 supabase.table("order_lines").insert(line_data).execute()
 
             # ⬇️ Markeer originele mail als verwerkt
-            supabase.table("orders").update({"structured_imported": True}).eq("id", email_id).execute()
+            supabase.table("emails").update({"structured_imported": True}).eq("id", email_id).execute()
 
             # ⬆️ Voeg toe aan resultaat
             imported += 1
             new_orders.append({
                 "id": email_id,
-                "subject": order["subject"],
+                "subject": email["subject"],
                 "customer_name": parsed.get("customer_name"),
                 "order_date": parsed.get("order_date"),
             })
 
         except Exception as e:
-            print(f"❌ Fout bij importeren van order '{order.get('subject', '')}': {e}")
+            print(f"❌ Fout bij importeren van order '{email.get('subject', '')}': {e}")
 
     return imported, new_orders
 

--- a/orca/llm_parser.py
+++ b/orca/llm_parser.py
@@ -76,7 +76,7 @@ def clean_json_output(raw_text):
     return raw_text
 
 def process_raw_emails():
-    response = supabase.table("orders").select("*").eq("llm_processed", False).execute()
+    response = supabase.table("emails").select("*").eq("llm_processed", False).execute()
     emails = response.data
 
     print(f"🔍 Gevonden ongeparste e-mails: {len(emails)}")
@@ -96,7 +96,7 @@ def process_raw_emails():
             cleaned_output = clean_json_output(raw_output)
             parsed_json = json.loads(cleaned_output)
 
-            supabase.table("orders").update({
+            supabase.table("emails").update({
                 "parsed_data": parsed_json,
                 "llm_processed": True
             }).eq("id", email_id).execute()

--- a/orca/order_pusher.py
+++ b/orca/order_pusher.py
@@ -47,13 +47,13 @@ def create_trello_card(order_id: str, product: Dict[str, Any]) -> bool:
             logger.error("Supabase client not initialized")
             return False
             
-        response = supabase.from_('orders').select('*').eq('id', order_id).execute()
+        response = supabase.from_('emails').select('*').eq('id', order_id).execute()
         if not response.data:
-            logger.error(f"Order {order_id} not found in database")
+            logger.error(f"Email {order_id} not found in database")
             return False
             
         order = response.data[0]
-        logger.info(f"Found order in database: {order['subject']}")
+        logger.info(f"Found email in database: {order['subject']}")
         
         url = f'https://api.trello.com/1/cards'
         headers = {

--- a/orca/supabase_client.py
+++ b/orca/supabase_client.py
@@ -24,7 +24,7 @@ def store_email(subject, sender, body, status="raw"):
         "status": status,
     }
     try:
-        response = supabase.table("orders").insert(data).execute()
-        print("✅ Order opgeslagen in Supabase:", response.data)
+        response = supabase.table("emails").insert(data).execute()
+        print("✅ Email opgeslagen in Supabase:", response.data)
     except Exception as e:
         print("❌ Fout bij opslaan in Supabase:", e)


### PR DESCRIPTION
- Updated the import_structured_orders function to process emails instead of orders.
- Modified llm_parser to select and update emails, ensuring proper handling of parsed data.
- Adjusted order_pusher to retrieve emails based on order ID.
- Changed supabase_client to insert emails instead of orders.
- Updated OrdersOverview and page components to fetch and display emails, aligning with the new data structure.

This refactor improves the clarity and accuracy of email processing within the application.