### PR TITLE
Enhance email processing by extracting forwarder information from Ret…

### DIFF
--- a/orca/email_parser.py
+++ b/orca/email_parser.py
@@ -65,9 +65,9 @@ def process_emails():
             subject = msg["subject"]
             sender = msg["from"]
             sender_name, sender_email = email.utils.parseaddr(sender)
-            # Extract forwarder (client) from Return-Path
-            return_path = msg.get("Return-Path")
-            forwarder_name, forwarder_email = email.utils.parseaddr(return_path) if return_path else (None, None)
+            # Extract return_path (client) from Return-Path
+            return_path_header = msg.get("Return-Path")
+            _, return_path = email.utils.parseaddr(return_path_header) if return_path_header else (None, None)
             body = extract_body(msg)
 
             sent_at = extract_sent_at(msg)
@@ -76,8 +76,8 @@ def process_emails():
                 sent_at = datetime.now().isoformat()
                 print(f"📆 Fallback naar huidige tijd: {sent_at}")
 
-            print(f"✉️ Verwerk e-mail: {subject} van {sender_email} verzonden op {sent_at} (forwarded by {forwarder_email})")
-            store_email(subject, sender_email, sender_name, body, sent_at, forwarder_email, forwarder_name)
+            print(f"✉️ Verwerk e-mail: {subject} van {sender_email} verzonden op {sent_at} (return-path: {return_path})")
+            store_email(subject, sender_email, sender_name, body, sent_at, return_path)
 
             server.add_flags(uid, [b"\\Seen"])
 

--- a/orca/email_parser.py
+++ b/orca/email_parser.py
@@ -65,6 +65,9 @@ def process_emails():
             subject = msg["subject"]
             sender = msg["from"]
             sender_name, sender_email = email.utils.parseaddr(sender)
+            # Extract forwarder (client) from Return-Path
+            return_path = msg.get("Return-Path")
+            forwarder_name, forwarder_email = email.utils.parseaddr(return_path) if return_path else (None, None)
             body = extract_body(msg)
 
             sent_at = extract_sent_at(msg)
@@ -73,8 +76,8 @@ def process_emails():
                 sent_at = datetime.now().isoformat()
                 print(f"📆 Fallback naar huidige tijd: {sent_at}")
 
-            print(f"✉️ Verwerk e-mail: {subject} van {sender_email} verzonden op {sent_at}")
-            store_email(subject, sender_email, sender_name, body, sent_at)
+            print(f"✉️ Verwerk e-mail: {subject} van {sender_email} verzonden op {sent_at} (forwarded by {forwarder_email})")
+            store_email(subject, sender_email, sender_name, body, sent_at, forwarder_email, forwarder_name)
 
             server.add_flags(uid, [b"\\Seen"])
 

--- a/orca/supabase_client.py
+++ b/orca/supabase_client.py
@@ -16,14 +16,16 @@ if not SUPABASE_URL or not SUPABASE_KEY:
 # create client
 supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
 
-def store_email(subject, sender_email, sender_name, body, sent_at=None, status="raw"):
-    """Store email with parsed sender information and optional sent timestamp"""
+def store_email(subject, sender_email, sender_name, body, sent_at=None, forwarder_email=None, forwarder_name=None, status="raw"):
+    """Store email with parsed sender and forwarder information and optional sent timestamp"""
     data = {
         "subject": subject,
         "sender_email": sender_email,
         "sender_name": sender_name,
         "email_body": body,
         "status": status,
+        "forwarder_email": forwarder_email,
+        "forwarder_name": forwarder_name,
     }
 
     if sent_at:

--- a/orca/supabase_client.py
+++ b/orca/supabase_client.py
@@ -16,16 +16,15 @@ if not SUPABASE_URL or not SUPABASE_KEY:
 # create client
 supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
 
-def store_email(subject, sender_email, sender_name, body, sent_at=None, forwarder_email=None, forwarder_name=None, status="raw"):
-    """Store email with parsed sender and forwarder information and optional sent timestamp"""
+def store_email(subject, sender_email, sender_name, body, sent_at=None, return_path=None, status="raw"):
+    """Store email with parsed sender and return_path information and optional sent timestamp"""
     data = {
         "subject": subject,
         "sender_email": sender_email,
         "sender_name": sender_name,
         "email_body": body,
         "status": status,
-        "forwarder_email": forwarder_email,
-        "forwarder_name": forwarder_name,
+        "return_path": return_path,
     }
 
     if sent_at:


### PR DESCRIPTION
Mathijs To test
* mark a forwarded email from Stean as unread
* hit the verwerk email button
* check if emails.return_path is set correctly

_Auto generated_


**What’s Changed**

-Database Schema:
- added one column emails.return_path 

Email Parsing Logic (email_parser.py):
- Now extracts the forwarder’s email and name from the Return-Path header in addition to the original sender from the From header.
- Passes both sender and forwarder information to the storage function.

Storage Logic (supabase_client.py):
- Updated store_email to accept and store forwarder_email and forwarder_name in the database.

**Why**
- To reliably identify which client forwarded each email, enabling better client tracking and filtering of incoming orders.

**How to Test**
1. Run the email parser with a forwarded email.
2. Check the emails table in Supabase to ensure both sender_email and forwarder_email are correctly populated.


----------


**What is return-path?**

<img width="1480" height="1320" alt="Screenshot 2025-07-12 at 13 42 37" src="https://github.com/user-attachments/assets/c1dcd0a9-8531-41f6-893e-4d8accbf4263" />

**Why should we use it?**
<img width="1210" height="1396" alt="Screenshot 2025-07-12 at 13 43 29" src="https://github.com/user-attachments/assets/290f1689-c2fa-4dac-b07d-45e810a10671" />


