### PR TITLE
Mathijs deleted at and more

### DIFF
--- a/orca-ui/src/app/orders/OrdersOverview.tsx
+++ b/orca-ui/src/app/orders/OrdersOverview.tsx
@@ -385,7 +385,7 @@ if (newEmails.length > 0) {
         </div>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
         <div className="space-y-2 max-h-[80vh] overflow-auto">
         {paginatedEmails.map((email) => (
   <Card 
@@ -421,7 +421,7 @@ if (newEmails.length > 0) {
         </div>
 
         {selectedEmail && (
-          <div className="col-span-1">
+          <div className="col-span-2">
             <Card>
               <CardHeader>
                 <CardTitle className="text-base">Email Details</CardTitle>

--- a/orca-ui/src/app/orders/OrdersOverview.tsx
+++ b/orca-ui/src/app/orders/OrdersOverview.tsx
@@ -165,6 +165,7 @@ if (newEmails.length > 0) {
   const { data: emailsData, error: emailsError } = await supabase
     .from("emails")
     .select("*")
+    .is("deleted_at", null)
     .order("created_at", { ascending: false });
 
   if (emailsError) throw emailsError;
@@ -175,12 +176,14 @@ if (newEmails.length > 0) {
   // Get ALL order lines to enrich the JSON with IDs
   const { data: allOrderLines } = await supabase
     .from("order_lines")
-    .select("id, order_id, product_name, quantity, unit, is_exported");
+    .select("id, order_id, product_name, quantity, unit, is_exported")
+    .is("deleted_at", null);
 
   // Get the mapping of email_id to order_id
   const { data: structuredEmails } = await supabase
     .from("orders")
-    .select("id, email_id, customer_name");
+    .select("id, email_id, customer_name")
+    .is("deleted_at", null);
 
 
   // Create a map of all order lines for enriching JSON with IDs

--- a/orca-ui/src/app/orders/OrdersOverview.tsx
+++ b/orca-ui/src/app/orders/OrdersOverview.tsx
@@ -382,7 +382,14 @@ if (newEmails.length > 0) {
         <h1 className="text-lg font-semibold">Orders</h1>
         <div className="flex flex-col items-end">
           <Button onClick={handleProcessAll} disabled={processing}>
-            {processing ? "Bezig..." : "Nieuwe e-mails verwerken"}
+            {processing ? (
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
+                <span>Bezig...</span>
+              </div>
+            ) : (
+              "Nieuwe e-mails verwerken"
+            )}
           </Button>
           {processResult && <span className="text-xs mt-1 text-muted-foreground">{processResult}</span>}
         </div>

--- a/orca-ui/src/app/orders/page.tsx
+++ b/orca-ui/src/app/orders/page.tsx
@@ -54,6 +54,7 @@ export default function Page() {
         let emailsQuery = supabase
           .from("emails")
           .select("*, email_body_html")
+          .is("deleted_at", null)
           .order("created_at", { ascending: false });
         
         if (clientId) {
@@ -68,7 +69,8 @@ export default function Page() {
         // Get orders - filter by client_id if specified
         let ordersQuery = supabase
           .from("orders")
-          .select("id, email_id, customer_name"); 
+          .select("id, email_id, customer_name")
+          .is("deleted_at", null); 
         
         if (clientId) {
           ordersQuery = ordersQuery.eq("client_id", clientId);
@@ -88,11 +90,13 @@ export default function Page() {
         let exportedLinesQuery = supabase
           .from("order_lines")
           .select("id, order_id, product_name, quantity, unit, is_exported")
+          .is("deleted_at", null)
           .eq("is_exported", true);
 
         let allOrderLinesQuery = supabase
           .from("order_lines")
-          .select("id, order_id, product_name, quantity, unit, is_exported");
+          .select("id, order_id, product_name, quantity, unit, is_exported")
+          .is("deleted_at", null);
 
         // Filter order lines by order_id if we have specific orders
         if (orderIds.length > 0) {

--- a/orca/email_parser.py
+++ b/orca/email_parser.py
@@ -24,7 +24,7 @@ def get_client_by_return_path(return_path):
         return None
     
     try:
-        response = supabase.table("clients").select("id").eq("return_path", return_path).execute()
+        response = supabase.table("clients").select("id").eq("return_path", return_path).is_("deleted_at", None).execute()
         if response.data:
             client_id = response.data[0]["id"]
             print(f"✅ Client gevonden voor return_path '{return_path}': client_id = {client_id}")

--- a/orca/import_structured_orders.py
+++ b/orca/import_structured_orders.py
@@ -16,6 +16,7 @@ def import_structured_orders():
         .select("*") \
         .eq("llm_processed", True) \
         .eq("structured_imported", False) \
+        .is_("deleted_at", None) \
         .execute()
 
     emails = response.data

--- a/orca/llm_parser.py
+++ b/orca/llm_parser.py
@@ -34,6 +34,7 @@ Je bent een slimme order-assistent. Haal de volgende informatie uit de onderstaa
 
 - Geef datums altijd in formaat "YYYY-MM-DD" (ISO 8601).
 - measuring units komt eigenlijk altijd in stuks, tenzij anders vermeld, dus 10 broden is product brood en quantity 10 stuks
+- soms wordt er naast 'quanity' en 'unit' bij een productnaam ook een verpakkingsmaat of hoeveelheid vermeld (b.v.Suikersticks (500 stuks) 1 Pack). Alleen in dat geval voeg je de verpakkingsmaat of hoeveelheid toe aan de productnaam. Zorg ervoor dat de unit and qunaity niet dubbel worden vermeld (dus niet "Koffiebonen 3x" 3x)
 - Vertaal relatieve termen zoals "morgen", "dinsdag" of "volgende week" naar een echte datum, gerekend vanaf vandaag: {today}.
 - "order_date" is altijd de verzenddatum van de e-mail: {email_date}.
 - Als een datum niet genoemd wordt, gebruik null.

--- a/orca/llm_parser.py
+++ b/orca/llm_parser.py
@@ -86,7 +86,7 @@ def clean_json_output(raw_text):
     return raw_text
 
 def process_raw_emails():
-    response = supabase.table("emails").select("*").eq("llm_processed", False).execute()
+    response = supabase.table("emails").select("*").eq("llm_processed", False).is_("deleted_at", None).execute()
     emails = response.data
 
     print(f"🔍 Gevonden ongeparste e-mails: {len(emails)}")

--- a/orca/order_pusher.py
+++ b/orca/order_pusher.py
@@ -47,7 +47,7 @@ def create_trello_card(order_id: str, product: Dict[str, Any]) -> bool:
             logger.error("Supabase client not initialized")
             return False
             
-        response = supabase.from_('emails').select('*').eq('id', order_id).execute()
+        response = supabase.from_('emails').select('*').eq('id', order_id).is_('deleted_at', None).execute()
         if not response.data:
             logger.error(f"Email {order_id} not found in database")
             return False
@@ -109,7 +109,7 @@ def update_product_sent_status(product: Dict[str, Any], sent: bool = True) -> bo
         logger.info(f"Updating export status for order_line_id {order_line_id} to {sent}")
         
         # First, verify the order line exists
-        check_response = supabase.table('order_lines').select('id, product_name, is_exported').eq('id', order_line_id).execute()
+        check_response = supabase.table('order_lines').select('id, product_name, is_exported').eq('id', order_line_id).is_('deleted_at', None).execute()
         
         if not check_response.data:
             logger.error(f"Order line with id {order_line_id} not found in database")


### PR DESCRIPTION
**In deze PR**
- deleted_at support voor emails, orders en order_lines
- Resize columns sizes to 25% - 50% -25%
- Spinner voor "Nieuwe emails verwerken" button
- Prompt eng to support adding "Verpakkingsmaten" to Productname when needed



**deleted_at support voor emails, orders en order_lines**
* test by setting deleted_at for emails.deleted_at orders. and orderlines. and check if front-end indeed doesn't return it
OR
double check if this indeed is shown in by the front-end and everytthings works

`select subject, sender_name, created_at, email_timestamp
from emails
WHERE return_path = 'orders+caf_=inbox=ordercatcher.nl@steansbeans.com'
and deleted_at is null
order by created_at desc;`


**Resize columns sizes to 25% - 50% -25%**
* Just play around and check if everything works as expected

**Spinner voor "Nieuwe emails verwerken" button**
* try "nieuwe email verwerken" button

**Prompt eng to support adding "Verpakkingsmaten" to Productname when needed**
* this was the specific email causing issues
* maybe check some more emails
<img width="1478" height="871" alt="Screenshot 2025-07-15 at 22 30 06" src="https://github.com/user-attachments/assets/4740319d-b3ad-4edb-be01-dbd15d3a6e44" />

