### PR TITLE
Use parsed_data.customer_name directly instead of orders table join

### DIFF
--- a/orca-ui/src/app/orders/OrdersOverview.tsx
+++ b/orca-ui/src/app/orders/OrdersOverview.tsx
@@ -46,6 +46,7 @@ interface Email {
   customer_name?: string; // <-- Add this line
   parsed_data: {
     products?: Product[];
+    customer_name?: string;
     [key: string]: unknown;
   };
   order?: Order;
@@ -413,7 +414,7 @@ if (newEmails.length > 0) {
               {newlyImportedEmailIds.has(email.id) && <span className="ml-2 text-blue-500 text-xs">🆕 Nieuw</span>}
             </CardTitle>
       <p className="text-xs text-muted-foreground">
-        {email.order?.customer_name || email.sender_name || email.sender_email} • {new Date(email.created_at).toLocaleString()}
+        {email.parsed_data?.customer_name || 'Geen klantnaam'} • {new Date(email.created_at).toLocaleString()}
       </p>
     </CardHeader>
   </Card>
@@ -458,7 +459,7 @@ if (newEmails.length > 0) {
             <Card>
             <CardHeader>
                 <CardTitle className="text-base">Resultaat email orders</CardTitle>
-                <p className="text-xs text-muted-foreground">Klant: {selectedEmail.order?.customer_name || selectedEmail.sender_name || selectedEmail.sender_email}</p>
+                <p className="text-xs text-muted-foreground">Klant: {selectedEmail.parsed_data?.customer_name || 'Geen klantnaam'}</p>
                 <p className="text-xs text-muted-foreground">
                 Datum: {formatDate(selectedEmail.created_at)}
                 </p>
@@ -527,7 +528,7 @@ if (newEmails.length > 0) {
                             onClick={() => {
                               const text = generateClipboardText(
                                 selectedEmail.parsed_data.products!,
-                                selectedEmail.order?.customer_name || selectedEmail.sender_name || selectedEmail.sender_email
+                                selectedEmail.parsed_data?.customer_name || 'Geen klantnaam'
                               );
                               copyToClipboard(text);
                             }}

--- a/orca/llm_parser.py
+++ b/orca/llm_parser.py
@@ -35,6 +35,7 @@ Je bent een slimme order-assistent. Haal de volgende informatie uit de onderstaa
 - Geef datums altijd in formaat "YYYY-MM-DD" (ISO 8601).
 - measuring units komt eigenlijk altijd in stuks, tenzij anders vermeld, dus 10 broden is product brood en quantity 10 stuks
 - soms wordt er naast 'quanity' en 'unit' bij een productnaam ook een verpakkingsmaat of hoeveelheid vermeld (b.v.Suikersticks (500 stuks) 1 Pack). Alleen in dat geval voeg je de verpakkingsmaat of hoeveelheid toe aan de productnaam. Zorg ervoor dat de unit and qunaity niet dubbel worden vermeld (dus niet "Koffiebonen 3x" 3x)
+- Voor "customer_name", zoek naar een bedrijfsnaam in de e-mail.
 - Vertaal relatieve termen zoals "morgen", "dinsdag" of "volgende week" naar een echte datum, gerekend vanaf vandaag: {today}.
 - "order_date" is altijd de verzenddatum van de e-mail: {email_date}.
 - Als een datum niet genoemd wordt, gebruik null.


### PR DESCRIPTION
- Frontend now gets customer_name directly from emails.parsed_data
- Removed fallback logic that used sender_name/sender_email as customer name
- Added customer_name to parsed_data TypeScript interface
- Updated LLM prompt to focus on business names for customer_name
- Eliminates timing issues and improves performance by avoiding complex joins